### PR TITLE
revert: Upgrade release-please-action to use Node.js 16

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,11 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
       - name: release-please-action
         uses: google-github-actions/release-please-action@v3.1.2
         with:


### PR DESCRIPTION
This commit reverts the previous change that updated the Node.js version in the workflow. The update is necessary for the `google-github-actions/release-please-action` and should be handled by that action itself.

Ref: 28cece4b95cb8fbd49d6cee1d00aa09f2864c332