### PR TITLE
feat: restrict staging & prod jobs to run on main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
     needs: dev-deploy
     environment:
       name: Staging
+    if: github.event.ref == 'refs/heads/main'
     steps:
       - run: echo "Deploying to Staging Environment"
 
@@ -26,5 +27,6 @@ jobs:
     needs: staging-deploy
     environment:
       name: Production
+    if: github.event.ref == 'refs/heads/main'
     steps:
       - run: echo "Deploying to Production Environment"


### PR DESCRIPTION
Restricting which branches can deploy into an environment to prevent accidental deployments by adding a conditional statement to staging and prod jobs so that they run only when commits are made to the main branch.